### PR TITLE
Add inject-only binary load option

### DIFF
--- a/doc/man6/cap32.6
+++ b/doc/man6/cap32.6
@@ -124,6 +124,9 @@ display short help and exits
 \fB\-i\fR, \fB\-\-inject\fR
 inject a binary in memory after the CPC startup finishes
 .TP
+\fB\-\-inject-only\fR
+inject a binary without modifying the program counter or stack
+.TP
 \fB\-o\fR, \fB\-\-offset\fR
 offset at which to inject the binary provided with -i (default: 0x6000)
 .TP

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -13,11 +13,16 @@
 #include "video.h"
 #include "glfuncs.h"  // For HAVE_GL
 
+enum {
+   OPT_INJECT_ONLY = 1,
+};
+
 const struct option long_options[] =
 {
    {"autocmd",  required_argument, nullptr, 'a'},
    {"cfg_file", required_argument, nullptr, 'c'},
    {"inject", required_argument, nullptr, 'i'},
+   {"inject-only", no_argument, nullptr, OPT_INJECT_ONLY},
    {"offset", required_argument, nullptr, 'o'},
    {"override", required_argument, nullptr, 'O'},
    {"sym_file", required_argument, nullptr, 's'},
@@ -39,6 +44,7 @@ void usage(std::ostream &os, char *progPath, int errcode)
    os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration file instead of the default.\n";
    os << "   -h/--help:              shows this help\n";
    os << "   -i/--inject=<file>:     inject a binary in memory after the CPC startup finishes\n";
+   os << "   --inject-only:          do not alter PC or stack when injecting a binary\n";
    os << "   -o/--offset=<address>:  offset at which to inject the binary provided with -i (default: 0x6000)\n";
    os << "   -O/--override:          override an option from the config. Can be repeated. (example: -O system.model=3)\n";
    os << "   -s/--sym_file=<file>:   use <file> as a source of symbols and entry points for disassembling in developers' tools.\n";
@@ -113,7 +119,7 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
       switch (c)
       {
-         case 'a':
+        case 'a':
             LOG_VERBOSE("Append to autocmd: " << optarg);
             args.autocmd += replaceCap32Keys(optarg);
             args.autocmd += "\n";
@@ -127,13 +133,17 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
             usage(std::cout, argv[0], 0);
             break;
 
-         case 'i':
-            args.binFile = optarg;
-            break;
+        case 'i':
+           args.binFile = optarg;
+           break;
 
-         case 'o':
-            args.binOffset = std::stol(optarg, nullptr, 0);
-            break;
+        case OPT_INJECT_ONLY:
+           args.injectOnly = true;
+           break;
+
+        case 'o':
+           args.binOffset = std::stol(optarg, nullptr, 0);
+           break;
 
          case 'O':
             {

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -13,6 +13,7 @@ class CapriceArgs
       std::string cfgFilePath;
       std::string binFile;
       size_t binOffset;
+      bool injectOnly = false;
       std::map<std::string, std::map<std::string, std::string>> cfgOverrides;
       std::string symFilePath;
 };

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -1265,7 +1265,7 @@ void emulator_shutdown ()
 
 
 
-void bin_load (const std::string& filename, const size_t offset)
+void bin_load (const std::string& filename, const size_t offset, bool inject_only)
 {
   LOG_INFO("Load " << filename << " in memory at offset 0x" << std::hex << offset);
   FILE *file;
@@ -1292,15 +1292,17 @@ void bin_load (const std::string& filename, const size_t offset)
     LOG_ERROR("Empty bin file");
     return;
   }
-  // Jump at the beginning of the program
-  z80.PC.w.l = offset;
-  // Setup the stack the way it would be if we had launch it with run"
-  z80_write_mem(--z80.SP.w.l, 0x0);
-  z80_write_mem(--z80.SP.w.l, 0x98);
-  z80_write_mem(--z80.SP.w.l, 0x7f);
-  z80_write_mem(--z80.SP.w.l, 0x89);
-  z80_write_mem(--z80.SP.w.l, 0xb9);
-  z80_write_mem(--z80.SP.w.l, 0xa2);
+  if (!inject_only) {
+    // Jump at the beginning of the program
+    z80.PC.w.l = offset;
+    // Setup the stack the way it would be if we had launch it with run"
+    z80_write_mem(--z80.SP.w.l, 0x0);
+    z80_write_mem(--z80.SP.w.l, 0x98);
+    z80_write_mem(--z80.SP.w.l, 0x7f);
+    z80_write_mem(--z80.SP.w.l, 0x89);
+    z80_write_mem(--z80.SP.w.l, 0xb9);
+    z80_write_mem(--z80.SP.w.l, 0xa2);
+  }
 }
 
 
@@ -2767,7 +2769,7 @@ int cap32_main (int argc, char **argv)
       if (!bin_loaded &&
           dwFrameCountOverall > CPC.boot_time) {
           bin_loaded = true;
-          if (!args.binFile.empty()) bin_load(args.binFile, args.binOffset);
+          if (!args.binFile.empty()) bin_load(args.binFile, args.binOffset, args.injectOnly);
       }
 
       if(!virtualKeyboardEvents.empty()

--- a/test/argparse.cpp
+++ b/test/argparse.cpp
@@ -100,3 +100,14 @@ TEST(argParseTest, replaceCap32KeysRepeatedKeywords)
 
   ASSERT_EQ(expected, replaceCap32Keys(command));
 }
+
+TEST(ArgParseTest, parseArgsInjectOnly)
+{
+   const char *argv[] = {"./cap32", "--inject-only"};
+   CapriceArgs args;
+   std::vector<std::string> slot_list;
+
+   parseArguments(2, const_cast<char **>(argv), slot_list, args);
+
+   ASSERT_TRUE(args.injectOnly);
+}


### PR DESCRIPTION
## Summary
- add `--inject-only` argument to CLI and CapriceArgs
- allow `bin_load` to skip PC/stack initialization
- document new flag in man page

## Testing
- `make unit_test` *(fails: sdl2-config: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a79d59fc832881e9bafa1ae1b5f5