### PR TITLE
Add GUI option to load binary into RAM

### DIFF
--- a/src/cap32.h
+++ b/src/cap32.h
@@ -449,6 +449,8 @@ std::string getConfigurationFilename(bool forWrite = false);
 void loadConfiguration (t_CPC &CPC, const std::string& configFilename);
 bool saveConfiguration (t_CPC &CPC, const std::string& configFilename);
 
+void bin_load(const std::string& filename, const size_t offset, bool inject_only);
+
 void ShowCursor(bool show);
 
 int cap32_main(int argc, char **argv);

--- a/src/gui/includes/CapriceLoadBinary.h
+++ b/src/gui/includes/CapriceLoadBinary.h
@@ -1,0 +1,31 @@
+// 'Load Binary' window for Caprice32
+
+#ifndef _WG_CAPRICE32LOADBINARY_H_
+#define _WG_CAPRICE32LOADBINARY_H_
+
+#include "wg_button.h"
+#include "wg_editbox.h"
+#include "wg_frame.h"
+#include "wg_label.h"
+
+namespace wGui {
+class CapriceLoadBinary : public CFrame {
+ public:
+  CapriceLoadBinary(const CRect& WindowRect, CWindow* pParent, CFontEngine* pFontEngine);
+  ~CapriceLoadBinary() override;
+  bool HandleMessage(CMessage* pMessage) override;
+
+ private:
+  CLabel* m_pFileLabel;
+  CEditBox* m_pFilePath;
+  CLabel* m_pOffsetLabel;
+  CEditBox* m_pOffset;
+  CButton* m_pLoadButton;
+  CButton* m_pCancelButton;
+
+  CapriceLoadBinary(const CapriceLoadBinary&) = delete;
+  CapriceLoadBinary& operator=(const CapriceLoadBinary&) = delete;
+};
+}
+
+#endif

--- a/src/gui/includes/CapriceMenu.h
+++ b/src/gui/includes/CapriceMenu.h
@@ -14,6 +14,7 @@ namespace wGui
     OPTIONS,
     LOAD_SAVE,
     MEMORY_TOOL,
+    LOAD_BIN,
     RESET,
     ABOUT,
     RESUME,

--- a/src/gui/src/CapriceLoadBinary.cpp
+++ b/src/gui/src/CapriceLoadBinary.cpp
@@ -1,0 +1,72 @@
+// 'Load Binary' window for Caprice32
+
+#include "CapriceLoadBinary.h"
+#include "cap32.h"
+#include "wg_messagebox.h"
+#include <cstdlib>
+#include <string>
+
+namespace wGui {
+CapriceLoadBinary::CapriceLoadBinary(const CRect& WindowRect, CWindow* pParent, CFontEngine* pFontEngine)
+    : CFrame(WindowRect, pParent, pFontEngine, "Load Binary", false) {
+  SetModal(true);
+
+  m_pFileLabel = new CLabel(CPoint(15, 25), this, "File:");
+  m_pFilePath = new CEditBox(CRect(CPoint(60, 20), 200, 20), this);
+  m_pFilePath->SetIsFocusable(true);
+
+  m_pOffsetLabel = new CLabel(CPoint(15, 55), this, "Offset:");
+  m_pOffset = new CEditBox(CRect(CPoint(60, 50), 100, 20), this);
+  m_pOffset->SetIsFocusable(true);
+  m_pOffset->SetContentType(CEditBox::HEXNUMBER);
+
+  m_pCancelButton = new CButton(CRect(CPoint(60, 90), 80, 20), this, "Cancel");
+  m_pCancelButton->SetIsFocusable(true);
+  m_pLoadButton = new CButton(CRect(CPoint(160, 90), 80, 20), this, "Load");
+  m_pLoadButton->SetIsFocusable(true);
+}
+
+CapriceLoadBinary::~CapriceLoadBinary() = default;
+
+bool CapriceLoadBinary::HandleMessage(CMessage* pMessage) {
+  bool bHandled = false;
+  if (pMessage) {
+    switch (pMessage->MessageType()) {
+      case CMessage::CTRL_SINGLELCLICK: {
+        if (pMessage->Destination() == this) {
+          if (pMessage->Source() == m_pCancelButton) {
+            CloseFrame();
+            bHandled = true;
+            break;
+          }
+          if (pMessage->Source() == m_pLoadButton) {
+            std::string filename = m_pFilePath->GetWindowText();
+            std::string offset_str = m_pOffset->GetWindowText();
+            if (filename.empty() || offset_str.empty()) {
+              auto* pMessageBox = new wGui::CMessageBox(
+                  CRect(CPoint(m_ClientRect.Width() / 2 - 125, m_ClientRect.Height() / 2 - 30), 250, 60),
+                  this, nullptr, "Error", "File or offset missing", CMessageBox::BUTTON_OK);
+              pMessageBox->SetModal(true);
+            } else {
+              size_t offset = strtoul(offset_str.c_str(), nullptr, 16);
+              bin_load(filename, offset, true);
+              CloseFrame();
+            }
+            bHandled = true;
+            break;
+          }
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  if (!bHandled) {
+    bHandled = CFrame::HandleMessage(pMessage);
+  }
+  return bHandled;
+}
+
+} // namespace wGui
+

--- a/src/gui/src/CapriceMenu.cpp
+++ b/src/gui/src/CapriceMenu.cpp
@@ -8,6 +8,7 @@
 #include "CapriceOptions.h"
 #include "CapriceLoadSave.h"
 #include "CapriceMemoryTool.h"
+#include "CapriceLoadBinary.h"
 #include "CapriceAbout.h"
 #include "cap32.h"
 
@@ -25,6 +26,7 @@ CapriceMenu::CapriceMenu(const CRect& WindowRect, CWindow* pParent, SDL_Surface*
     { MenuItem::OPTIONS, "Options" },
     { MenuItem::LOAD_SAVE, "Load / Save" },
     { MenuItem::MEMORY_TOOL, "Memory tool" },
+    { MenuItem::LOAD_BIN, "Load binary" },
     { MenuItem::RESET, "Reset (F5)" },
     { MenuItem::ABOUT, "About" },
     { MenuItem::RESUME, "Resume" },
@@ -101,6 +103,10 @@ bool CapriceMenu::HandleMessage(CMessage* pMessage)
               bHandled = true;
               selected = MenuItem::MEMORY_TOOL;
               break;
+            case SDLK_b:
+              bHandled = true;
+              selected = MenuItem::LOAD_BIN;
+              break;
             case SDLK_F5:
               bHandled = true;
               selected = MenuItem::RESET;
@@ -155,6 +161,11 @@ bool CapriceMenu::HandleMessage(CMessage* pMessage)
     case MenuItem::MEMORY_TOOL:
       {
         /*CapriceMemoryTool* pMemoryTool = */new CapriceMemoryTool(CRect(ViewToClient(CPoint(m_pScreenSurface->w /2 - 165, m_pScreenSurface->h /2 - 140)), 330, 270), this, nullptr);
+        break;
+      }
+    case MenuItem::LOAD_BIN:
+      {
+        /*CapriceLoadBinary* pLoadBinary = */new CapriceLoadBinary(CRect(ViewToClient(CPoint(m_pScreenSurface->w /2 - 165, m_pScreenSurface->h /2 - 75)), 330, 120), this, nullptr);
         break;
       }
     case MenuItem::RESET:


### PR DESCRIPTION
## Summary
- Add new "Load binary" menu entry accessible via F1
- Provide dialog to choose binary file and offset then load into CPC RAM
- Expose `bin_load` to other modules

## Testing
- `make unit_test` *(fails: sdl2-config: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898896661708328b8358e628aaeb7ff